### PR TITLE
Add -G the foregroun equivalent to -g

### DIFF
--- a/doc/maxwell.8
+++ b/doc/maxwell.8
@@ -110,6 +110,9 @@ equivalent to	-d 41 -c 16 -s 8
 TP
 .I -g
 equivalent to	-d 43 -c 16 -s 16
+TP
+.I -G
+equivalent to   -g   but not daemonizing
 
 .PP
 Three are intended to let a cautious system administrator
@@ -126,7 +129,7 @@ TP
 equivalent to	-w 109 -p 4
 
 .PP
-Each of -f, -g, -x, -y, -z, and the default with
+Each of -f, -g, -G, -x, -y, -z, and the default with
 no options uses a different prime number for the wait.
 
 Other options are provided for testing.

--- a/src/maxwell.c
+++ b/src/maxwell.c
@@ -3,9 +3,9 @@
 	and feed it to random(4)
 
 	It borrows some code from Folkert van Heusden's
-	timer entropy demon http://www.vanheusden.com/te/
+	timer entropy daemon http://www.vanheusden.com/te/
 	but the two programs are quite different.
-	
+
 	License is GPL v2, the same as the earlier code.
 
 	If anyone needs it under another Open Source
@@ -64,7 +64,7 @@ u32 sha_c[] = {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0} ;
 
 /*
 	constant for multiplications
-	
+
 	11, 37 and 71 are 3, 5 and 7 mod 8
 	so they all give some mixing in the low bits
 	and they each do it differently
@@ -206,7 +206,7 @@ int main( int argc, char **argv)
 	// documented in getuid(1) as "always successful"
 	// so do not bother checking for failure
 	user = geteuid() ;
-	
+
 	/*
 		set up various things
 	*/
@@ -246,7 +246,7 @@ int main( int argc, char **argv)
 			a = 0 ;
 		// main loop; sample & mix
 		for( i = 0 ; i < loops ; i++)	{
-			// get 16 samples for entropy 
+			// get 16 samples for entropy
 			for( j = 0 ; j < 16 ; j++ )	{
 				usleep(delay) ;
 				// mix in a sample

--- a/src/maxwell.c
+++ b/src/maxwell.c
@@ -74,7 +74,7 @@ u32 sha_c[] = {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0} ;
 int main( int argc, char **argv)
 {
 	unsigned a, b, p, delay, limit, loops ;
-	int i, j, out, output, ret, claim, mul, mix ;
+	int i, j, out, output, foreground, ret, claim, mul, mix ;
 	char *u, *v ;
 
 	/*
@@ -97,6 +97,7 @@ int main( int argc, char **argv)
 		output to standard out
 	*/
 	output = 1 ;
+	foreground = 0 ;
 
 	/* argument processing */
 	prog_name = *argv ;
@@ -160,6 +161,13 @@ int main( int argc, char **argv)
 					claim = 16 ;
 					limit = 16 ;
 					break ;
+				// as -g but don't daemonize
+				case 'G' :
+					delay = primes[1] ;
+					claim = 16 ;
+					limit = 16 ;
+					foreground = 1;
+					break ;
 				// for the paranoids
 				// -x, -y -z do more loops
 				case 'x' :
@@ -215,7 +223,7 @@ int main( int argc, char **argv)
 	if( demon )	{
 		if( (output=open("/dev/random", O_WRONLY)) == -1)
 			error_exit("failed to open /dev/random") ;
-		if (daemon(-1, -1) == -1)
+		if( !foreground && daemon(-1, -1) == -1)
 			error_exit("failed to become daemon process") ;
 		openlog( prog_name, (LOG_CONS|LOG_PID), LOG_DAEMON) ;
 	}

--- a/src/maxwell.c
+++ b/src/maxwell.c
@@ -300,7 +300,7 @@ void message(const char *reason)
 void usage()
 {
 	fprintf(stderr, "usage: %s [-p <number>] [-d <number>] [-s <number>] [-c number]\n", prog_name) ;
-	fprintf(stderr, "usage: %s [-f|-g|-m|-t|-x|-y|-z|-<digit>]\n", prog_name) ;
+	fprintf(stderr, "usage: %s [-f|-g|-G|-m|-t|-x|-y|-z|-<digit>]\n", prog_name) ;
 	exit(-1) ;
 }
 

--- a/src/qht.c
+++ b/src/qht.c
@@ -10,7 +10,7 @@
 
 	Underlying primitive is IDEA
 	multiplication which mixes
-	a pair of 16-bit objects 
+	a pair of 16-bit objects
 
 	This is analogous to the
 	pseudo-Hadamard transform

--- a/src/timermod.c
+++ b/src/timermod.c
@@ -39,7 +39,7 @@
 	or sec and usec
 	so multiplier is a million
 	or a billion
-	
+
 	if you want total time
 	(B * sec) + nsec
 	(M * sec) + usec

--- a/systemd/maxwell-boot.service
+++ b/systemd/maxwell-boot.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Maxwell set to quickly seed /dev/random
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/maxwell -G
+
+[Install]
+WantedBy=sysinit.target

--- a/systemd/maxwell.service
+++ b/systemd/maxwell.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Maxwell - Daemon for gathering entropy from a timer and feeding it to random(4)
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/maxwell
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
This pull request adds -G option to make Maxwell run like "maxwell -g" but without terminal. This PR also contains whitespace fixes.
